### PR TITLE
Change part tagging to automatically match all crewable parts in the first three space station nodes to the correct experiments.

### DIFF
--- a/GameData/RP-1/Science/Configure.cfg
+++ b/GameData/RP-1/Science/Configure.cfg
@@ -941,7 +941,7 @@
 }
 
 //Space Stations Prototypes
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:AFTER[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:AFTER[zzzKerbalism]
 {
 	@MODULE[HardDrive]
 	{
@@ -1076,7 +1076,7 @@
 }
 
 //Early Space Stations
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:AFTER[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:AFTER[zzzKerbalism]
 {
 	@MODULE[HardDrive]
 	{

--- a/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/StationExperiments.cfg
@@ -1,11 +1,15 @@
 // ============================================================================
 // Add tag to parts
 // ============================================================================
-@PART[SXTCrewCabSSP10|SXTCrewCabSSP20|ROStat-sspx-habitation-125-1|ROStat-Station|L25mSci|FASAGeminiMOLSci|sspx-core-125-1|salyut1-4|crewCabin|ROStat-Salyut|Large_Crewed_Lab|sspx-habitation-125-1|sspx-habitation-1875-2]:BEFORE[RP-0-Kerbalism]
+@PART[*]:HAS[#TechRequired[spaceStationPrototypes],#CrewCapacity[>0]]:BEFORE[zzzKerbalism]
 {
 	%capsuleTier = StationPrototypeAndDevelopment
 }
-@PART[almaz3-5|rn_almaz_ops4|salyut6|salyut7|skylab|SXTISSHabISK30|ROStat-Skylab]:BEFORE[RP-0-Kerbalism]
+@PART[*]:HAS[#TechRequired[spaceStationDev],#CrewCapacity[>0]]:BEFORE[zzzKerbalism]
+{
+	%capsuleTier = StationPrototypeAndDevelopment
+}
+@PART[*]:HAS[#TechRequired[earlySpaceStations],#CrewCapacity[>0]]:BEFORE[zzzKerbalism]
 {
 	%capsuleTier = EarlyStation
 }
@@ -41,7 +45,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -87,7 +91,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -134,7 +138,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -181,7 +185,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -229,7 +233,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -276,7 +280,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -323,7 +327,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -371,7 +375,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[StationPrototypeAndDevelopment]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -423,7 +427,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = RP0longDurationHabit1
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -470,7 +474,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -517,7 +521,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -564,7 +568,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -611,7 +615,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -658,7 +662,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -706,7 +710,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -753,7 +757,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -800,7 +804,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -847,7 +851,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -894,7 +898,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -942,7 +946,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -990,7 +994,7 @@ EXPERIMENT_DEFINITION
 		IncludeExperiment = 
   	}
 }
-@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[#capsuleTier[EarlyStation]]:FOR[zzzKerbalism]
 {
 	MODULE
 	{


### PR DESCRIPTION
No more explicit part tagging is required.
All crewable parts receive their correct experiments, and the experiments run and complete without issues.